### PR TITLE
Added iOS 8 Diagnostics app to hidden apps

### DIFF
--- a/ALApplicationTableDataSource.m
+++ b/ALApplicationTableDataSource.m
@@ -92,6 +92,7 @@ static UIImage *defaultImage;
 		                            @"com.apple.AdSheetPad",
 		                            @"com.apple.DataActivation",
 		                            @"com.apple.DemoApp",
+		                            @"com.apple.Diagnostics",
 		                            @"com.apple.fieldtest",
 		                            @"com.apple.iosdiagnostics",
 		                            @"com.apple.iphoneos.iPodOut",


### PR DESCRIPTION
Added @"com.apple.Diagnostics" to hiddenDisplayIdentifiers (@"com.apple.iosdiagnostics" appears to not properly hide the Diagnostics app in iOS 8)